### PR TITLE
Add msbuild property to restore SDK bits on build

### DIFF
--- a/HelloAndroid/HelloAndroid.csproj
+++ b/HelloAndroid/HelloAndroid.csproj
@@ -3,5 +3,7 @@
     <TargetFramework>netcoreapp5.0</TargetFramework>
     <Configuration>Debug</Configuration>
     <RuntimeIdentifier>android.21-arm64</RuntimeIdentifier>
+    
+    <AndroidRestoreOnBuild>True</AndroidRestoreOnBuild>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Should we add this to the defaults?