### PR TITLE
[ci] Use pre-installed Xcode 12.3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,8 +62,6 @@ jobs:
   pool:
     vmImage: macOS-latest
   variables:
-    - group: xamops-azdev-secrets
-    - group: Xamarin-Secrets
     - name: LogDirectory
       value: $(Build.ArtifactStagingDirectory)/logs
     - name: DotNet.Root
@@ -91,12 +89,8 @@ jobs:
         boots $(iOS.Pkg)
       displayName: install .NET workloads
 
-    - task: provisionator@2
-      displayName: install Xcode
-      inputs:
-        github_token: $(github--pat--vs-mobiletools-engineering-service2)
-        provisioning_script: $(System.DefaultWorkingDirectory)/scripts/provision.csx
-        provisioning_extra_args: '-v -v -v -v'
+    - bash: sudo xcode-select -s /Applications/Xcode_12.3.app
+      displayName: select Xcode 12.3
 
     - bash: |
         set -x


### PR DESCRIPTION
The hosted macOS images should have [all recent Xcode versions][0]
pre-installed, and we can use `xcode-select` to use the version needed
by iOS.

[0]: https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md#xcode