### PR TITLE
Update iOS sample to be visible in dark mode

### DIFF
--- a/HelloiOS/AppDelegate.cs
+++ b/HelloiOS/AppDelegate.cs
@@ -21,11 +21,13 @@ namespace HelloiOS
             // create a new window instance based on the screen size
             Window = new UIWindow(UIScreen.MainScreen.Bounds);
             var vc = new UIViewController ();
+            UIColor backgroundColor = UIDevice.CurrentDevice.CheckSystemVersion(13, 0) ? UIColor.SystemBackgroundColor : UIColor.White;
             vc.View.AddSubview (new UILabel (Window.Frame)
             {
-                BackgroundColor = UIColor.White,
+                BackgroundColor = backgroundColor,
                 TextAlignment = UITextAlignment.Center,
-                Text = "Hello, .NET 6!"
+                Text = "Hello, .NET 6!",
+                TextColor = UIColor.Blue
             });
             Window.RootViewController = vc;
 


### PR DESCRIPTION
Thanks for sharing these samples and making it so easy to get started with .NET 6 for Xamarin!

I had an issue where it looked like the iOS sample wasn't deploying properly, because my simulator was set to use dark mode, and the sample background color was hard-coded. Currently, if the sample is run on a device in dark mode, the status bar, background, and label are all rendered white.

This PR addresses that by checking for the iOS 13 API, and using system background color if available, otherwise it will default to white. For simplicity the label color is set to just blue. This isn't an ideal pattern, but I wanted to keep the changes minimal while ensuring compatibility and a good first run experience.

I tested with the simulator for iOS 14.4 and iOS 11.4.

I didn't see a CLA or advice for contributing aside from the COC. Let me know if I should do anything to make this PR welcome, or I can log an issue if you're not accepting PRs.

Thanks again for the great work on Xamarin and .NET 6!