### PR TITLE
Fix the ordering of the VSCode prompts.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,7 +20,7 @@
             // we only support android at this time.
             "label": "Run",
             "type": "shell",
-            "command": "dotnet build ${input:project} \"-t:Run\" --no-restore -p:TargetFramework=${input:targetframework} -p:AndroidAttachDebugger=${input:attach} -p:AndroidSdbHostPort=10000 -p:Configuration=${input:configuration}",
+            "command": "dotnet build ${input:project} \"-t:Run\" --no-restore -p:TargetFramework=${input:targetframework} -p:Configuration=${input:configuration} -p:AndroidAttachDebugger=${input:attach} -p:AndroidSdbHostPort=10000",
             "group": {
                 "kind": "build",
                 "isDefault": true


### PR DESCRIPTION
The `Build` command was prompting for `Project->Build Target->Configuration`.
However the `Run` command was prompting for
`Project->TargetFramework->AttachDebugger->Configuration`.

It makes more sense to prompt for the debugger last. That way the order
of the prompts are similar.