### PR TITLE
[catalyst] make label visible in dark mode

### DIFF
--- a/HelloMacCatalyst/AppDelegate.cs
+++ b/HelloMacCatalyst/AppDelegate.cs
@@ -23,9 +23,9 @@ namespace HelloiOS
             var vc = new UIViewController ();
             vc.View.AddSubview (new UILabel (Window.Frame)
             {
-                BackgroundColor = UIColor.White,
                 TextAlignment = UITextAlignment.Center,
-                Text = "Hello, .NET 6!"
+                Text = "Hello, .NET 6!",
+                TextColor = UIColor.Blue,
             });
             Window.RootViewController = vc;
 


### PR DESCRIPTION
In dark mode, the app was completely white.

It seems we can just use no background color, and I get the system default background color.

I used `Blue` text like the iOS sample.