### PR TITLE
Update ios simulator RuntimeIdentifiers in samples

### DIFF
--- a/HelloMaui/HelloMaui.csproj
+++ b/HelloMaui/HelloMaui.csproj
@@ -8,7 +8,7 @@
     <ApplicationTitle>MAUI</ApplicationTitle>
     <ApplicationVersion>1.0</ApplicationVersion>
     <AndroidVersionCode>1</AndroidVersionCode>
-    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">ios-x64</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">iossimulator-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-maccatalyst'">maccatalyst-x64</RuntimeIdentifier>
   </PropertyGroup>
   <ItemGroup>

--- a/HelloiOS/HelloiOS.csproj
+++ b/HelloiOS/HelloiOS.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0-ios</TargetFramework>
-    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
+    <RuntimeIdentifier>iossimulator-x64</RuntimeIdentifier>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
The ios simulator RID is now iossimulator-x64 (or iossimulator-arm64) in .NET 6 Preview 3