### PR TITLE
Bump to AndroidX net6preview03

### DIFF
--- a/HelloAndroid/HelloAndroid.csproj
+++ b/HelloAndroid/HelloAndroid.csproj
@@ -4,8 +4,6 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.3.0.1-net6preview01" />
-    <!--TODO: Xamarin.AndroidX.Arch.Core.Runtime should be transitive dependency and not needed-->
-    <PackageReference Include="Xamarin.AndroidX.Arch.Core.Runtime" Version="2.1.0.8-net6preview01" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.3.0.1-net6preview03.4680155" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I updated our AndroidX packages via:

https://github.com/xamarin/AndroidX/pull/247

The current build is based on the .NET 6 Preview 3 bits.